### PR TITLE
PAR-1541: Country Autocomplete (chosen replacement)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,13 @@
     ],
     "require": {
         "php": "~8.1.0",
-        "aws/aws-sdk-php":  "~3.209.0",
+        "aws/aws-sdk-php": "~3.209.0",
         "bjeavons/zxcvbn-php": "~1.3.0",
         "commerceguys/intl": "^1.0",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "deblan/csv-validator": "dev-master",
+        "drupal/a11y_autocomplete_element": "^1.0",
         "drupal/address": "~1.11.0",
         "drupal/audit_log": "~3.0.0",
         "drupal/autologout": "~1.3.0",
@@ -85,8 +86,8 @@
         "drupal/search_api": "~1.23.0",
         "drupal/search_api_opensearch": "~1.0.0",
         "drupal/symfony_mailer": "~1.0.0",
-        "drupal/trance": "8.x-1.x-dev",
         "drupal/token": "~1.9.0",
+        "drupal/trance": "8.x-1.x-dev",
         "drupal/twig_field_value": "~2.0.0",
         "drupal/twig_tweak": "~3.1.0",
         "drupal/ultimate_cron": "~2.0.0",
@@ -211,6 +212,9 @@
             },
             "drupal/views_data_export": {
                 "Allow output file scheme to be chosen": "https://www.drupal.org/files/issues/2021-03-01/allow-configurable-filesystems_3200974-6.patch"
+            },
+            "drupal/a11y_autocomplete_element": {
+                "Adds correct classes for Gov UK theme": "./patches/govuk-theme-classes.patch"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df2f2890cba1eac8398664d28c7772be",
+    "content-hash": "320b0f2580a8998c220afab06bbc86f8",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -1984,6 +1984,54 @@
             },
             "abandoned": "roave/better-reflection",
             "time": "2022-05-31T18:46:25+00:00"
+        },
+        {
+            "name": "drupal/a11y_autocomplete_element",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/a11y_autocomplete_element.git",
+                "reference": "1.0.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/a11y_autocomplete_element-1.0.3.zip",
+                "reference": "1.0.3",
+                "shasum": "944e097af5ab95c1078c07e1e2b74213ea204183"
+            },
+            "require": {
+                "drupal/core": ">=9.2"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.3",
+                    "datestamp": "1650864012",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "DanielVeza",
+                    "homepage": "https://www.drupal.org/user/3362504"
+                },
+                {
+                    "name": "larowlan",
+                    "homepage": "https://www.drupal.org/user/395439"
+                }
+            ],
+            "description": "Provides an accessible autocomplete element and widget to replace select elements",
+            "homepage": "https://www.drupal.org/project/a11y_autocomplete_element",
+            "support": {
+                "source": "https://git.drupalcode.org/project/a11y_autocomplete_element"
+            }
         },
         {
             "name": "drupal/address",
@@ -20624,5 +20672,5 @@
         "php": "~8.1.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/patches/govuk-theme-classes.patch
+++ b/patches/govuk-theme-classes.patch
@@ -1,0 +1,13 @@
+diff --git a/js/a11y-autocomplete.js b/js/a11y-autocomplete.js
+index af23bdf..944576b 100644
+--- a/js/a11y-autocomplete.js
++++ b/js/a11y-autocomplete.js
+@@ -30,7 +30,7 @@
+     };
+     const input = document.createElement('input');
+     input.type = 'text';
+-    input.classList.add('form-text', 'form-element', 'form-element--type-text');
++    input.classList.add('form-text', 'form-element', 'form-control', 'form-element--type-text');
+     const parent = el.parentNode;
+     el.classList.add('visually-hidden');
+     parent.insertBefore(input, el);

--- a/sync/chosen.settings.yml
+++ b/sync/chosen.settings.yml
@@ -4,6 +4,7 @@ minimum_single: 20
 minimum_multiple: 20
 disable_search_threshold: 0
 minimum_width: 0
+max_shown_results: null
 use_relative_width: false
 jquery_selector: 'select:visible'
 search_contains: false
@@ -12,8 +13,10 @@ allow_single_deselect: false
 disabled_themes:
   bartik: '0'
   seven: '0'
+  govuk: '0'
+  govuk_par: '0'
   par_theme: '0'
-chosen_include: 1
+chosen_include: 0
 placeholder_text_multiple: 'Choose some options'
 placeholder_text_single: 'Choose an option'
 no_results_text: 'No results match'

--- a/sync/core.extension.yml
+++ b/sync/core.extension.yml
@@ -1,6 +1,7 @@
 _core:
   default_config_hash: R4IF-ClDHXxblLcG0L7MgsLvfBIMAvi_skumNFQwkDc
 module:
+  a11y_autocomplete_element: 0
   address: 0
   audit_log: 0
   automated_cron: 0

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParAddressForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParAddressForm.php
@@ -97,7 +97,7 @@ class ParAddressForm extends ParFormPluginBase {
     ];
 
     $form['country_code'] = [
-      '#type' => 'select',
+      '#type' => 'a11y_autocomplete',
       '#options' => $this->getCountryRepository()->getList(NULL),
       '#title' => $this->t('Country'),
       '#default_value' => $this->getDefaultValuesByKey('country_code', $cardinality, 'GB'),


### PR DESCRIPTION
 - Removes chosen from the front end (its not good for accessibility)
 - Introduces a11y_autocomplete_element module and required drupal package
 - Swaps out the Country select for the 'a11y_autocomplete' form element
 - Adds a patch to add the additional classes required by govuk-theme