### PR TITLE
PAR-2340 - Adding error message to removal of inspection plan

### DIFF
--- a/web/modules/features/par_partnership_document_remove_flows/src/Form/ParRemoveInspectionPlanForm.php
+++ b/web/modules/features/par_partnership_document_remove_flows/src/Form/ParRemoveInspectionPlanForm.php
@@ -85,6 +85,7 @@ class ParRemoveInspectionPlanForm extends ParBaseForm {
       '#title' => $this->t('Enter the reason you are removing this inspection plan'),
       '#type' => 'textarea',
       '#rows' => 5,
+      '#required' => TRUE,
       '#default_value' => $this->getFlowDataHandler()->getDefaultValues('remove_reason', FALSE),
     ];
 


### PR DESCRIPTION
Adding error message and required error UI to inspection plan removal

## Description
Makes the textarea required, which triggers the error class and necessary UI 

## Motivation and Context
https://regulatorydelivery.atlassian.net/browse/PAR-2340

## How Has This Been Tested?
Followed steps to recreate from JIRA tasks

## Screenshots (if appropriate):
![315952815-08bb7c02-4ece-4620-90bb-bcd8b359c4ed](https://github.com/OfficeForProductSafetyAndStandards/beis-primary-authority-register/assets/162973285/4b49e343-1347-41b3-8b1c-cfb88fda978a)


## Types of changes
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] non breaking change (non-breaking change which is not issue related)
- [ ] Security related (updates which are security related)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
