### PR TITLE
PAR-2341 - Adding required field for removing advice reason

### DIFF
--- a/web/modules/features/par_partnership_document_remove_flows/src/Form/ParRemoveAdviceForm.php
+++ b/web/modules/features/par_partnership_document_remove_flows/src/Form/ParRemoveAdviceForm.php
@@ -87,6 +87,7 @@ class ParRemoveAdviceForm extends ParBaseForm {
       '#title' => $this->t('Enter the reason you are removing this advice'),
       '#type' => 'textarea',
       '#rows' => 5,
+      '#required' => TRUE,
       '#default_value' => $this->getFlowDataHandler()->getDefaultValues('remove_reason', FALSE),
     ];
 


### PR DESCRIPTION
Adding error message and required error UI to advice removal

## Description
Makes the textarea required, which triggers the error class and necessary UI 

## Motivation and Context
https://regulatorydelivery.atlassian.net/browse/PAR-2341

## How Has This Been Tested?
Followed steps to recreate from JIRA tasks

## Screenshots (if appropriate):
![Screenshot 2024-03-28 at 10 01 31](https://github.com/OfficeForProductSafetyAndStandards/beis-primary-authority-register/assets/162973285/4b99bc64-bdf4-412a-b1ac-0042989117d0)

## Types of changes
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] non breaking change (non-breaking change which is not issue related)
- [ ] Security related (updates which are security related)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
