### PR TITLE
PAR-2450 - Updating page title to use view title

### DIFF
--- a/sync/views.view.advanced_partnership_search.yml
+++ b/sync/views.view.advanced_partnership_search.yml
@@ -31,7 +31,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Primary Authority Register | Advanced partnership search'
+      title: 'Advanced partnership search'
       fields:
         counter:
           id: counter
@@ -2084,7 +2084,7 @@ display:
     display_plugin: data_export
     position: 2
     display_options:
-      title: 'Primary Authority Register | Partnership Report Download'
+      title: 'Partnership Report Download'
       fields:
         id:
           id: id

--- a/sync/views.view.notifications.yml
+++ b/sync/views.view.notifications.yml
@@ -263,7 +263,7 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: 'No action required'
+          empty: ''
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true

--- a/sync/views.view.notifications.yml
+++ b/sync/views.view.notifications.yml
@@ -263,7 +263,7 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: 'No action required'
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true

--- a/sync/views.view.par_user_authorities.yml
+++ b/sync/views.view.par_user_authorities.yml
@@ -21,7 +21,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Primary Authority Register | Your authorities'
+      title: 'Your authorities'
       fields:
         id:
           id: id

--- a/sync/views.view.par_user_organisations.yml
+++ b/sync/views.view.par_user_organisations.yml
@@ -21,7 +21,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Primary Authority Register | Your organisations'
+      title: 'Your organisations'
       fields:
         id:
           id: id

--- a/sync/views.view.par_user_partnerships.yml
+++ b/sync/views.view.par_user_partnerships.yml
@@ -24,7 +24,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Primary Authority Register | Your partnerships'
+      title: 'Your partnerships'
       fields:
         id:
           id: id
@@ -1096,7 +1096,7 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      title: 'Primary Authority Register | Pending applications'
+      title: 'Pending applications'
       sorts:
         partnership_status:
           id: partnership_status

--- a/sync/views.view.partnership_search.yml
+++ b/sync/views.view.partnership_search.yml
@@ -25,7 +25,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Primary Authority Register | Search for a partnership'
+      title: 'Search for a partnership'
       fields:
         id:
           id: id

--- a/sync/views.view.primary_authority_register.yml
+++ b/sync/views.view.primary_authority_register.yml
@@ -24,7 +24,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Primary Authority Register | Search for a partnership'
+      title: 'Search for a partnership'
       fields:
         id_1:
           id: id_1

--- a/web/themes/custom/par_theme/par_theme.theme
+++ b/web/themes/custom/par_theme/par_theme.theme
@@ -2,6 +2,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Site\Settings;
+use Drupal\Core\Routing\RouteObjectInterface;
 
 /**
  * Implements hook_preprocess().
@@ -32,9 +33,21 @@ function par_theme_preprocess_html(array &$variables) {
     $secondary_title = array_shift($title_fragments);
     array_push($title_fragments, $secondary_title);
   }
+
   if (empty($title_fragments)) {
-    unset($variables['head_title']['title']);
+
+    $route_name = \Drupal::routeMatch()->getRouteName();
+    if (strpos($route_name, 'view') === 0) {
+      $request = \Drupal::service('request_stack')->getCurrentRequest();
+      $route = $request->attributes->get(RouteObjectInterface::ROUTE_OBJECT);
+      if ($route instanceof Route) {
+        $variables['head_title']['title'] = \Drupal::service('title_resolver')->getTitle($request, $route);
+      }
+    } else {
+      unset($variables['head_title']['title']);
+    }
   }
+
   else {
     $variables['head_title']['title'] = implode(' | ', $title_fragments);
   }


### PR DESCRIPTION
## Description
Updates the page title to include view title in the theme_preprocess 

 - Updates views titles that has incorrect duplication { view_name } \ Primary Authority Register'

## Motivation and Context
https://regulatorydelivery.atlassian.net/browse/PAR-2450

## How Has This Been Tested?
Checked through the site, only pages driven by views suffered the issue

## Screenshots (if appropriate):

## Types of changes
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] non breaking change (non-breaking change which is not issue related)
- [ ] Security related (updates which are security related)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
