### PR TITLE
PAR-2452 - Making view use Ajax for form submission to maintain keybo…

### DIFF
--- a/sync/views.view.advanced_partnership_search.yml
+++ b/sync/views.view.advanced_partnership_search.yml
@@ -2001,6 +2001,7 @@ display:
           contextual_filters_or: false
       relationships: {  }
       css_class: par-advanced-partnership-search-list
+      use_ajax: true
       header:
         par_flow_link:
           id: par_flow_link

--- a/sync/views.view.par_people.yml
+++ b/sync/views.view.par_people.yml
@@ -1138,6 +1138,7 @@ display:
           plugin_id: standard
           required: false
       css_class: user-management-list
+      use_ajax: true
       group_by: true
       header:
         par_flow_link:

--- a/sync/views.view.par_user_authorities.yml
+++ b/sync/views.view.par_user_authorities.yml
@@ -575,6 +575,7 @@ display:
           plugin_id: entity_reverse
           required: false
       css_class: par-user-authority-list
+      use_ajax: true
       group_by: true
       header: {  }
       footer: {  }

--- a/sync/views.view.par_user_enforcements.yml
+++ b/sync/views.view.par_user_enforcements.yml
@@ -1325,6 +1325,7 @@ display:
           plugin_id: standard
           required: false
       css_class: par-user-enforcement-list
+      use_ajax: true
       group_by: false
       header:
         par_flow_link:

--- a/sync/views.view.par_user_partnerships.yml
+++ b/sync/views.view.par_user_partnerships.yml
@@ -1064,6 +1064,7 @@ display:
           plugin_id: standard
           required: false
       css_class: par-user-partnership-list
+      use_ajax: true
       header: {  }
       footer:
         par_flow_link:

--- a/sync/views.view.partnership_search.yml
+++ b/sync/views.view.partnership_search.yml
@@ -1204,6 +1204,7 @@ display:
           preserve_facet_query_args: false
           contextual_filters_or: false
       relationships: {  }
+      use_ajax: true
       header: {  }
       footer:
         par_flow_link:


### PR DESCRIPTION
## Description
Set all views that use exposed filters to use ajax to maintain keyboard focus and consistent behaviour across the application

## Motivation and Context
https://regulatorydelivery.atlassian.net/browse/PAR-2452

## How Has This Been Tested?
Visit the following pages and note the age doe snot reload on form submit for the exposed filters:

/search/advanced/partnerships
/members
/authorities
/enforcement-notices
/partnerships
/partnerships/pending
/search/partnerships

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] non breaking change (non-breaking change which is not issue related)
- [ ] Security related (updates which are security related)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
