### PR TITLE
PAR-2476 - Adding default hash_salt to CI settings.php to repair buil…

### DIFF
--- a/web/sites/default/settings.local.ci-sanitise.php
+++ b/web/sites/default/settings.local.ci-sanitise.php
@@ -16,3 +16,5 @@ $settings['trusted_host_patterns'] = [''];
 // Ensure ci always runs with the same memory that other environments do.
 ini_set('memory_limit', '512M');
 ini_set('max_execution_time', 60);
+
+$settings['hash_salt'] = 'y9fBHyfS_V90Ubd42vTlAnp0VvZ7Ljgbb68UTNLsBBgXAkGViooWGE59oevcc6UU2X0ObGIIlA';


### PR DESCRIPTION
## Description
Adds hash_salt as env variable ares not loading in pipeline for environment

## Motivation and Context
https://regulatorydelivery.atlassian.net/browse/PAR-2476

## How Has This Been Tested?
Investigation into repeatable pipeline fail

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] non breaking change (non-breaking change which is not issue related)
- [ ] Security related (updates which are security related)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
