### PR TITLE
Remove the code that adds these Operation Links 

### DIFF
--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParSicCodeDisplay.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParSicCodeDisplay.php
@@ -110,17 +110,6 @@ class ParSicCodeDisplay extends ParFormPluginBase {
       catch (ParFlowException $e) {
         $this->getLogger($this->getLoggerChannel())->notice($e);
       }
-      try {
-        // Remove the SIC code.
-        $params = ['field_sic_code_delta' => $delta];
-        $options = ['attributes' => ['aria-label' => $this->t("Remove the SIC code @label", ['@label' => strtolower((string) $label)])]];
-        $operations['remove'] = $this->getFlowNegotiator()->getFlow()
-          ->getOperationLink('remove_field_sic_code', 'remove sic code', $params, $options);
-
-      }
-      catch (ParFlowException $e) {
-        $this->getLogger($this->getLoggerChannel())->notice($e);
-      }
 
       // Display operation links if any are present.
       if (!empty(array_filter($operations))) {

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParTradingNameDisplay.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParTradingNameDisplay.php
@@ -104,17 +104,6 @@ class ParTradingNameDisplay extends ParFormPluginBase {
       catch (ParFlowException $e) {
         $this->getLogger($this->getLoggerChannel())->notice($e);
       }
-      try {
-        // Remove the trading name.
-        $params['trading_name_delta'] = $delta;
-        $options = ['attributes' => ['aria-label' => $this->t("Remove the trading name @label", ['@label' => strtolower((string) $trading_name)])]];
-        $operations['remove'] = $this->getFlowNegotiator()->getFlow()
-          ->getOperationLink('remove_trading_name', 'remove trading name', $params, $options);
-
-      }
-      catch (ParFlowException $e) {
-        $this->getLogger($this->getLoggerChannel())->notice($e);
-      }
 
       // Display operation links if any are present.
       if (!empty(array_filter($operations))) {


### PR DESCRIPTION
The two Operation Links are for 
- 'remove_field_sic_code'
- 'remove_trading_name'

They are not implmented and the exception is logged everytime the page is rendered.